### PR TITLE
add jet_lookup_queryset support for models

### DIFF
--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -75,7 +75,8 @@ def jet_select2_lookups(field):
                 'class': 'ajax',
                 'data-app-label': app_label,
                 'data-model': model_name,
-                'data-ajax--url': reverse('jet:model_lookup')
+                'data-field-name': field.name,
+                'data-ajax--url': reverse('jet:model_lookup')+ f"?field_name={field.name}"
             }
 
             initial_value = field.value()


### PR DESCRIPTION
* Modify `jet_select2_lookups` tag (used by jet internally for relationship fields) to pass field name  
* Look for `jet_lookup_queryset` in jet's model lookup, if available take the queryset, this function will also get context information about app, model, field name etc.